### PR TITLE
Startup: skip genesis-replay when blockchain.startHeight > 1

### DIFF
--- a/app/services/Startup.scala
+++ b/app/services/Startup.scala
@@ -309,8 +309,15 @@ class Startup @Inject()(
       def latestExplorerBlockHeight = blockchainBlocks.Service.getLatestBlockHeight
 
       def checkAndInsertBlock(latestChainHeight: Int, latestExplorerBlockHeight: Int) = if (latestExplorerBlockHeight == 0) {
+        // When starting from a non-genesis height (e.g. blockchain.startHeight=22M
+        // because upstream RPCs don't have block 1), onGenesis() is both pointless
+        // (genesis app_state at the chain's actual genesis is mostly empty for
+        // mantle-1) and harmful: it parallel-fans out GetAccount calls per genesis
+        // account, instantly tripping upstream nginx rate limits (429 Too Many
+        // Requests, then JSON_PARSE_EXCEPTION on the HTML body, scheduler stuck
+        // in retry loop). Skip it.
         for {
-          _ <- onGenesis()
+          _ <- if (blockchainStartHeight <= 1) onGenesis() else Future.successful(())
           _ <- insertBlock(blockchainStartHeight)
         } yield ()
       } else {

--- a/app/utilities/JSON.scala
+++ b/app/utilities/JSON.scala
@@ -20,10 +20,20 @@ object JSON {
 
   def getResponseFromJson[T <: BaseResponse](response: Future[WSResponse])(implicit exec: ExecutionContext, logger: Logger, module: String, reads: Reads[T]): Future[T] = {
     response.map { response =>
-      Json.fromJson[T](response.json) match {
-        case JsSuccess(value: T, _: JsPath) => value
-        case jsError: JsError => logJsonError(response.json.toString(), jsError)
-          new Failure(response.json.toString()).throwBaseException()
+      try {
+        Json.fromJson[T](response.json) match {
+          case JsSuccess(value: T, _: JsPath) => value
+          case jsError: JsError => logJsonError(response.json.toString(), jsError)
+            new Failure(response.json.toString()).throwBaseException()
+        }
+      } catch {
+        // When the upstream returns non-JSON (typical example: nginx 429 HTML),
+        // include the HTTP status + content-type so the operator can see at a
+        // glance whether it's a rate limit, 5xx, redirect, etc., without having
+        // to decode the JsonParseException's internal message.
+        case e: JsonParseException =>
+          logger.error(s"non-JSON response: status=${response.status} content-type=${response.header("Content-Type").getOrElse("?")}")
+          throw e
       }
     }.recover {
       case jsonParseException: JsonParseException => constants.Response.JSON_PARSE_EXCEPTION.throwBaseException(jsonParseException)


### PR DESCRIPTION
## Why

Starting from a non-genesis height (e.g. `BLOCKCHAIN_START_HEIGHT=22000000` because all our public upstream RPCs are pruned and don't retain block 1) currently stalls the indexer permanently. `BLOCK_SCHEDULER`'s first iteration calls `onGenesis()` unconditionally when the DB is empty:

- `onGenesis()` parses `genesis.json` then fans out parallel `GetAccount`/`GetBalance`/etc per account.
- Free-tier public RPCs (Polkachu, PublicNode, StakerHouse) trip rate limits instantly under that fanout — they respond with **HTTP 429 + `nginx/1.24.0` HTML error page**.
- The HTML body throws `JsonParseException` in `utilities.JSON.getResponseFromJson`, propagates as `BaseException`.
- The scheduler's recover block catches it (logs `Blockchain height update failed: 1`) and the next tick retries the same fanout → same hang. No block ever inserts.

Genesis-replay isn't needed when starting from a recent height — Validator/Account/Balance tables populate naturally as blocks are processed.

## Patch

In `Startup#blockScheduler.runner`'s `checkAndInsertBlock`, only call `onGenesis()` when `blockchainStartHeight <= 1`. Otherwise jump straight to `insertBlock(blockchainStartHeight)`.

Also adds a one-line diagnostic log on `JsonParseException` showing upstream HTTP status + content-type — makes "JSON_PARSE_EXCEPTION" failures self-explanatory (`status=429 content-type=text/html`).

## Verification

Ran locally against `rpc.assetmantle.one` (Polkachu/PublicNode/StakerHouse pool) with `-Dblockchain.startHeight=22000000`:

- Before: 0 blocks inserted, scheduler stuck in retry loop, only 429 errors logged.
- After: indexer progresses from fresh DB at ~40 blocks/min. Validator/Account tables fill as data is seen.

Catch-up from `22M` → chain head (~`22.12M`) ≈ 48h on the public aggregator. Faster against a private RPC.

## Backwards compat

Default `startHeight=1` is unchanged → genesis-replay still runs as before. Only behaviour change is when an operator explicitly sets `startHeight > 1` (previously effectively broken).