### PR TITLE
fix(startup,charts): seed Token table on non-genesis boot + format USD axis

### DIFF
--- a/app/services/Startup.scala
+++ b/app/services/Startup.scala
@@ -316,8 +316,18 @@ class Startup @Inject()(
         // account, instantly tripping upstream nginx rate limits (429 Too Many
         // Requests, then JSON_PARSE_EXCEPTION on the HTML body, scheduler stuck
         // in retry loop). Skip it.
+        //
+        // BUT we still need the Token table seeded with the staking denom row, or
+        // any view that calls blockchainTokens.Service.getTotalBondedAmount (e.g.
+        // /component/validatorInfo, dashboard cards) 500s with CRYPTO_TOKEN_NOT_FOUND.
+        // insertAllTokensOnStart() pulls live current-state from REST so it works
+        // independent of the genesis file.
+        def seedTokensIfEmpty: Future[Unit] = blockchainTokens.Service.getAllDenoms.flatMap { denoms =>
+          if (denoms.isEmpty) insertAllTokensOnStart() else Future.successful(())
+        }
+
         for {
-          _ <- if (blockchainStartHeight <= 1) onGenesis() else Future.successful(())
+          _ <- if (blockchainStartHeight <= 1) onGenesis() else seedTokensIfEmpty
           _ <- insertBlock(blockchainStartHeight)
         } yield ()
       } else {
@@ -384,8 +394,19 @@ class Startup @Inject()(
       .setFrom("mantle1e2xkc64txeegnuplkr4w2pn6pqzt2qh9ffdlf5")
       .setName(StringID("276").asProtoStringID).build())(header)
 
+    // When started from a non-genesis height (blockchain.startHeight > 1), the
+    // Token table never gets seeded by onGenesis(), and any view that calls
+    // getTotalBondedAmount (validatorDetails, dashboard cards) 500s with
+    // CRYPTO_TOKEN_NOT_FOUND. Seed it once on every boot if empty —
+    // insertAllTokensOnStart pulls live current state from REST so it works
+    // independent of the genesis file. Idempotent thanks to the empty check.
+    val seedTokens = blockchainTokens.Service.getAllDenoms.flatMap { denoms =>
+      if (denoms.isEmpty) insertAllTokensOnStart() else Future.successful(())
+    }
+
     (for {
       _ <- addMissing
+      _ <- seedTokens
     } yield ()
       ).recover {
       case exception: Exception => logger.error(exception.getLocalizedMessage)

--- a/public/javascripts/chart/lineChart.js
+++ b/public/javascripts/chart/lineChart.js
@@ -3,6 +3,18 @@ function lineChart(chartID, keys, values, label, showLegend, xLabel, yLabel) {
     let nameList = keys.replace('List(', '').replace(')', '').split(', ');
     let valueList = values.replace('Iterable(', '').replace(')', '').split(', ');
 
+    function formatYValue(value) {
+        if (yLabel !== 'USD') return value;
+        let v = Number(value);
+        if (!isFinite(v)) return value;
+        if (v === 0) return '$0';
+        let abs = Math.abs(v);
+        if (abs >= 1) return '$' + v.toLocaleString('en-US', {maximumFractionDigits: 2});
+        if (abs >= 0.01) return '$' + v.toFixed(4);
+        let decimals = Math.min(12, Math.max(4, -Math.floor(Math.log10(abs)) + 3));
+        return '$' + v.toFixed(decimals);
+    }
+
     Chart.defaults.global.legend.display = showLegend;
     let chartData = {
         labels: nameList,
@@ -32,8 +44,21 @@ function lineChart(chartID, keys, values, label, showLegend, xLabel, yLabel) {
                     scaleLabel: {
                         display: true,
                         labelString: yLabel
+                    },
+                    ticks: {
+                        callback: function (value) {
+                            return formatYValue(value);
+                        }
                     }
                 }]
+            },
+            tooltips: {
+                callbacks: {
+                    label: function (item) {
+                        let prefix = label ? label + ': ' : '';
+                        return prefix + formatYValue(item.yLabel);
+                    }
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary
Two bugs surfaced once we started running with `blockchain.startHeight > 1` (PR #98 skipped `onGenesis()` to dodge the upstream-RPC 429 storm).

1. **`validatorDetails` 500 → `CRYPTO_TOKEN_NOT_FOUND`.** The Token table was only seeded inside `onGenesis()`, so any view calling `getTotalBondedAmount` (validator detail, dashboard cards) errored out. `Startup.startFixes` now runs a one-shot `insertAllTokensOnStart()` if the Token table is empty — uses live REST (`totalSupply`, `stakingPool`, `mintingInflation`, `communityPool`), idempotent across restarts.
2. **Token-price chart unreadable.** The y-axis and tooltip rendered in scientific notation (`2.48E-5`). `lineChart.js` now formats values when `yLabel === 'USD'`:
   - `≥ $1` → thousand-separated, 2 decimals
   - `≥ $0.01` → 4 decimals
   - `< $0.01` → enough decimals to preserve 4 significant figures (`$0.00002489`)

## Test plan
- [x] `sbt dist` succeeds (built `ghcr.io/assetmantle/client:seed-tokens-v2` digest `sha256:b152bb13f210bf4a4618c27980eee5afb41ccbed0fcb997b6d9f2f535ff1a655`)
- [x] Live deploy on Akash DSEQ 26587209 (tx `7F6D298B…`, manifest accepted)
- [x] `https://explorer.assetmantle.one/component/validatorInfo?address=mantlevaloper1qpkax9dxey2ut8u39meq8ewjp6rfsm3hlsyceu` returns 200 (3338 bytes), no more `CRYPTO_TOKEN_NOT_FOUND`
- [x] `lineChart.js` served by the explorer contains `formatYValue` + `toLocaleString` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)