### PR TITLE
build: enable sbt-digest for content-addressed asset URLs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,12 @@ resolvers += "Maven Central Server" at "https://repo1.maven.org/maven2"
 
 scalaVersion := "2.13.11"
 
+// Run sbt-digest over public/* during `dist`, so @routes.Assets.versioned
+// emits content-addressed URLs (e.g. /assets/-<sha1>-lineChart.js) and the
+// Play Assets controller can serve them with long-TTL immutable caching.
+// Root scope = applies to the production pipeline (sbt dist / sbt stage).
+pipelineStages := Seq(digest)
+
 libraryDependencies ++= Seq(ws, specs2 % Test, guice, caffeine)
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,9 @@ logLevel := Level.Warn
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
+
+// Fingerprint static assets (CSS/JS/fonts) at build time so URLs produced by
+// @routes.Assets.versioned("...") become content-addressed. Pairs with
+// Play's default long-TTL Cache-Control on versioned assets so a deploy
+// auto-invalidates browser caches without manual ?version= bumps.
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")


### PR DESCRIPTION
## Summary
- Adds the standard Play web-asset pipeline plugin (`sbt-digest`) and enables it during `dist`/`stage`.
- After this lands, `@routes.Assets.versioned(\"...\")` (already used by 24 templates) emits content-addressed URLs at build time:
  - before: `/assets/javascripts/chart/lineChart.js` (cache `max-age=3600`)
  - after:  `/assets/javascripts/chart/ad1c28c9e1743c53446832c659baab1f-lineChart.js` (cache `max-age=31536000, immutable`)
- Browser caches now auto-invalidate on every deploy that touches an asset, with no manual `?version=` bumps and no custom helper.

## Test plan
- [x] Built `ghcr.io/assetmantle/client:digest-pipeline` (`sha256:a2deab2d178e48ce1992076a06ead9fa3b9b4240c5eaac4efe060f18dd353d9a`); the assets jar contains `*.md5` digest manifest entries.
- [x] Live deploy on Akash DSEQ 26587209 (tx `C57E2B21…`).
- [x] Homepage `<script>` tags now reference fingerprinted paths like `/assets/javascripts/90cf30a35cd4eea1643aaa478440fbe0-theme.js`.
- [x] Fingerprinted URL responds with `cache-control: public, max-age=31536000, immutable`.
- [x] `https://explorer.assetmantle.one/component/tokensPrices` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)